### PR TITLE
Adding configuration for auth method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Stim Changelog
 
+## 0.0.5
+
+### Improvements
+* Configurable auth methods.  A config entry of `auth.method` or command line parameter `--auth-method` can be used to specify the authenticate method (ex: ldap, github, etc.).
+
 ## 0.0.4
 ### BREAKING CHANGES
 * Changing parameter for `stim aws login`. Changed -m to -a to be clear about account name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Stim Changelog
 
-## 0.0.5
+## 0.0.5 (in-development)
 
 ### Improvements
-* Configurable auth methods.  A config entry of `auth.method` or command line parameter `--auth-method` can be used to specify the authenticate method (ex: ldap, github, etc.).
+* Configurable auth methods.  A config entry of `auth.method` or command line parameter `--auth-method` can be used to specify the authentication method (ex: ldap, github, etc.).
 
 ## 0.0.4
 ### BREAKING CHANGES

--- a/pkg/vault/auth.go
+++ b/pkg/vault/auth.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"strings"
 	"syscall"
 )
@@ -92,7 +93,8 @@ func (v *Vault) userLogin() error {
 	// }
 
 	// Login with LDAP and create a token
-	secret, err := v.client.Logical().Write("auth/ldap/login/"+username, map[string]interface{}{
+	authPath := path.Join("auth/", v.config.AuthPath, "/login/", username)
+	secret, err := v.client.Logical().Write(authPath, map[string]interface{}{
 		"password": password,
 	})
 	if err != nil {
@@ -129,7 +131,7 @@ func (v *Vault) IsNewLogin() bool {
 // getCredentials gathers username and password from the user
 // Could also use: github.com/hashicorp/vault/helper/password
 func (v *Vault) getCredentials() (string, string, error) {
-	fmt.Println("Vault needs your LDAP Linux user/pass.")
+	fmt.Println("Please enter your [" + v.config.AuthPath + "] credentials")
 	if v.config.Username != "" {
 		fmt.Printf("Username (%s): ", v.config.Username)
 	} else {

--- a/pkg/vault/auth.go
+++ b/pkg/vault/auth.go
@@ -69,10 +69,8 @@ func (v *Vault) isCurrentTokenValid() bool {
 	return true
 }
 
-// userLogin asks user for LDAP login to Authenticate with Vault
+// userLogin authenticates with Vault and obtains a user token
 func (v *Vault) userLogin() error {
-	// Sadly we will assume LDAP login (for now)
-	// Maybe someday vault will allow anonymous access to "vault auth list"
 
 	if v.config.Noprompt == true {
 		return errors.New("No interactive prompt is set, but user input is required to continue")
@@ -92,7 +90,7 @@ func (v *Vault) userLogin() error {
 	// 	log.Fatal("Username does not match BSD 4.3 standards (32 character string 0f [a-z0-9_])")
 	// }
 
-	// Login with LDAP and create a token
+	// Login and obtain a token
 	authPath := path.Join("auth/", v.config.AuthPath, "/login/", username)
 	secret, err := v.client.Logical().Write(authPath, map[string]interface{}{
 		"password": password,

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -17,6 +17,7 @@ type Vault struct {
 }
 
 type Config struct {
+	AuthPath             string
 	Noprompt             bool
 	Address              string
 	Username             string
@@ -42,6 +43,12 @@ func New(config *Config) (*Vault, error) {
 	// Ensure that the Vault address is set
 	if config.Address == "" {
 		return nil, v.newError("Vault address not set")
+	}
+
+	// Set a default auth method to ldap if not set
+	// TODO: change this to token auth as it is more generic
+	if config.AuthPath == "" {
+		config.AuthPath = "ldap"
 	}
 
 	// Configure new Vault Client

--- a/stim/rootcmd.go
+++ b/stim/rootcmd.go
@@ -26,6 +26,9 @@ func initRootCommand(viper *viper.Viper) *cobra.Command {
 	viper.BindPFlag("verbose", cmd.PersistentFlags().Lookup("verbose"))
 	cmd.PersistentFlags().BoolP("noprompt", "x", false, "Do not prompt for input. Will default to true for Jenkin builds.")
 	viper.BindPFlag("noprompt", cmd.PersistentFlags().Lookup("noprompt"))
+	cmd.PersistentFlags().StringP("auth-method", "", "", "Default authentication method (ex: ldap, github, etc.)")
+	viper.BindPFlag("auth.method", cmd.PersistentFlags().Lookup("auth-method"))
+
 	if homeDir == "" {
 		if err != nil {
 			stim.log.Debug("Could not get the home dir:", err)

--- a/stim/vault.go
+++ b/stim/vault.go
@@ -8,7 +8,6 @@ import (
 
 // Vault is the interface for Hashicorp Vault wrapper methods
 // The main input is the vault-address
-// Will prompt the user for their LDAP username and password
 // Will update the user's ~/.vault-token file with a new token
 func (stim *Stim) Vault() *vault.Vault {
 	if stim.vault == nil {

--- a/stim/vault.go
+++ b/stim/vault.go
@@ -35,6 +35,7 @@ func (stim *Stim) Vault() *vault.Vault {
 		vault, err := vault.New(&vault.Config{
 			Address:              stim.GetConfig("vault-address"), // Default is 127.0.0.1
 			Noprompt:             stim.GetConfigBool("noprompt") == false && stim.IsAutomated(),
+			AuthPath:             stim.GetConfig("auth.method"),
 			Username:             username, // If set in the configs, pass in user
 			InitialTokenDuration: timeInDuration,
 			Log:                  stim.log,

--- a/stimpacks/vault/command.go
+++ b/stimpacks/vault/command.go
@@ -16,7 +16,7 @@ func (v *Vault) Command(viper *viper.Viper) *cobra.Command {
 	var vaultCmd = &cobra.Command{
 		Use:   "vault",
 		Short: "Vault helper",
-		Long:  "Vault LDAP login and AWS access",
+		Long:  "Vault login and access",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Help()
 		},
@@ -30,7 +30,7 @@ func (v *Vault) Command(viper *viper.Viper) *cobra.Command {
 	var loginCmd = &cobra.Command{
 		Use:   "login",
 		Short: "login to Vault",
-		Long:  "Login into Vault using LDAP",
+		Long:  "Login and obtain a token from Vault",
 		Run: func(cmd *cobra.Command, args []string) {
 			v.Login()
 		},

--- a/stimpacks/vault/login.go
+++ b/stimpacks/vault/login.go
@@ -1,7 +1,6 @@
 package vault
 
 // Login will connect to Vault server and login
-// Right now this only logs in using LDAP
 func (v *Vault) Login() {
 	// Get a new Vault from the API
 	_ = v.stim.Vault()


### PR DESCRIPTION
* Added configurable auth methods. A config entry of `auth.method` or command line parameter `--auth-method` can be used to specify the authenticate method (ex: ldap, github, etc.).