### PR TITLE
adding hack to disable bell being used in all prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Improvements
 * Configurable auth methods.  A config entry of `auth.method` or command line parameter `--auth-method` can be used to specify the authentication method (ex: ldap, github, etc.).
+* Prompt interface would trigger terminal bell when using arrow key to navigate the menu. This has been removed.
 
 ## 0.0.4
 ### BREAKING CHANGES

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/PagerDuty/go-pagerduty v0.0.0-20181104233218-fe8f9c4593d0
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/aws/aws-sdk-go v1.19.11
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/cornelk/hashmap v1.0.0
 	github.com/go-ini/ini v1.42.0
 	github.com/golang/snappy v0.0.1 // indirect

--- a/stim/prompt.go
+++ b/stim/prompt.go
@@ -1,9 +1,35 @@
 package stim
 
 import (
-	"github.com/manifoldco/promptui"
+	"os"
 	"strings"
+
+	"github.com/chzyer/readline"
+	"github.com/manifoldco/promptui"
 )
+
+// stderr implements an io.WriteCloser that skips the terminal bell character
+// (ASCII code 7), and writes the rest to os.Stderr. It's used to replace
+// readline.Stdout, that is the package used by promptui to display the prompts.
+type stderr struct{}
+
+// Write implements an io.WriterCloser over os.Stderr, but it skips the terminal
+// bell character.
+func (s *stderr) Write(b []byte) (int, error) {
+	if len(b) == 1 && b[0] == readline.CharBell {
+		return 0, nil
+	}
+	return os.Stderr.Write(b)
+}
+
+// Close implements an io.WriterCloser over os.Stderr.
+func (s *stderr) Close() error {
+	return os.Stderr.Close()
+}
+
+func init() {
+	readline.Stdout = &stderr{}
+}
 
 // PromptBool asks the user a yes/no question
 func (stim *Stim) PromptBool(label string, override bool, defaultvalue bool) (bool, error) {

--- a/stim/prompt.go
+++ b/stim/prompt.go
@@ -8,14 +8,14 @@ import (
 	"github.com/manifoldco/promptui"
 )
 
-// stderr implements an io.WriteCloser that skips the terminal bell character
+// noBellStderr implements an io.WriteCloser that skips the terminal bell character
 // (ASCII code 7), and writes the rest to os.Stderr. It's used to replace
 // readline.Stdout, that is the package used by promptui to display the prompts.
-type stderr struct{}
+type noBellStderr struct{}
 
 // Write implements an io.WriterCloser over os.Stderr, but it skips the terminal
 // bell character.
-func (s *stderr) Write(b []byte) (int, error) {
+func (s *noBellStderr) Write(b []byte) (int, error) {
 	if len(b) == 1 && b[0] == readline.CharBell {
 		return 0, nil
 	}
@@ -23,12 +23,12 @@ func (s *stderr) Write(b []byte) (int, error) {
 }
 
 // Close implements an io.WriterCloser over os.Stderr.
-func (s *stderr) Close() error {
+func (s *noBellStderr) Close() error {
 	return os.Stderr.Close()
 }
 
 func init() {
-	readline.Stdout = &stderr{}
+	readline.Stdout = &noBellStderr{}
 }
 
 // PromptBool asks the user a yes/no question


### PR DESCRIPTION
Fix found from: https://github.com/smallstep/cli/blob/master/ui/ui.go#L15-L36