### PR TITLE
fixed how Errors are handled

### DIFF
--- a/pkg/vault/auth.go
+++ b/pkg/vault/auth.go
@@ -15,7 +15,7 @@ import (
 
 // Login will authenticate the user with Vault
 // Will detect if user needs to re-login
-func (v *Vault) Login() error {
+func (v *Vault) Login() Error {
 	// get the token from the user's environment
 	if v.client.Token() != "" {
 		v.log.Debug("Reading token from environment 'VAULT_TOKEN'")
@@ -24,7 +24,7 @@ func (v *Vault) Login() error {
 		v.tokenHelper = token.InternalTokenHelper{}
 		token, err := v.tokenHelper.Get()
 		if err != nil {
-			return err
+			return v.parseError(err)
 		}
 
 		if token != "" {

--- a/pkg/vault/auth.go
+++ b/pkg/vault/auth.go
@@ -15,7 +15,7 @@ import (
 
 // Login will authenticate the user with Vault
 // Will detect if user needs to re-login
-func (v *Vault) Login() Error {
+func (v *Vault) Login() error {
 	// get the token from the user's environment
 	if v.client.Token() != "" {
 		v.log.Debug("Reading token from environment 'VAULT_TOKEN'")
@@ -24,7 +24,7 @@ func (v *Vault) Login() Error {
 		v.tokenHelper = token.InternalTokenHelper{}
 		token, err := v.tokenHelper.Get()
 		if err != nil {
-			return v.parseError(err)
+			return v.parseError(err).(error)
 		}
 
 		if token != "" {
@@ -53,7 +53,7 @@ func (v *Vault) GetToken() (string, error) {
 	v.tokenHelper = token.InternalTokenHelper{}
 	token, err := v.tokenHelper.Get()
 	if err != nil {
-		return "", v.parseError(err)
+		return "", v.parseError(err).(error)
 	}
 
 	return token, nil
@@ -144,7 +144,7 @@ func (v *Vault) getCredentials() (string, string, error) {
 
 	if len(username) <= 0 { // If user just clicked enter
 		if v.config.Username == "" { // If there also isn't default
-			return "", "", v.newError("No username given")
+			return "", "", v.newError("No username given").(error)
 		}
 		username = v.config.Username
 	} else {
@@ -154,7 +154,7 @@ func (v *Vault) getCredentials() (string, string, error) {
 	fmt.Print("Password: ")
 	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
-		return "", "", v.parseError(err)
+		return "", "", v.parseError(err).(error)
 	}
 	fmt.Println("")
 	password := string(bytePassword)

--- a/pkg/vault/error.go
+++ b/pkg/vault/error.go
@@ -17,9 +17,9 @@ type CustomVaultError struct {
 	OriginalError error
 }
 
-// Error is custom error interface with one method that will block other functions
+// customError is custom error interface with one method that will block other functions
 // from using this Error. This is not interchangeable with the standard error.
-type Error interface {
+type CustomError interface {
 	Error() string
 	blockInterface()
 }
@@ -34,16 +34,14 @@ func (verr CustomVaultError) blockInterface() {
 }
 
 // parseError parses known errors into more user-friendly messages
-func (v *Vault) parseError(err error) Error {
+func (v *Vault) parseError(err error) CustomError {
 
 	// Provent parseError from calling parseError again
-	if serr, ok := err.(Error); ok {
+	if serr, ok := err.(CustomError); ok {
 		return serr
 	}
 
-	// var verr CustomVaultError
 	verr := &CustomVaultError{OriginalError: err}
-	// verr.OriginalError = err
 
 	// Catch some known HTTP errors
 	if uerr, ok := err.(*url.Error); ok {
@@ -72,6 +70,6 @@ func (v *Vault) parseError(err error) Error {
 }
 
 // newError returns a new error based on a given string
-func (v *Vault) newError(msg string) Error {
+func (v *Vault) newError(msg string) CustomError {
 	return v.parseError(errors.New(msg))
 }

--- a/pkg/vault/mounts.go
+++ b/pkg/vault/mounts.go
@@ -11,7 +11,7 @@ func (v *Vault) GetMounts(mountType string) ([]string, error) {
 
 	mounts, err := v.client.Sys().ListMounts()
 	if err != nil {
-		return nil, v.parseError(err)
+		return nil, v.parseError(err).(error)
 	}
 
 	var result []string

--- a/pkg/vault/secrets.go
+++ b/pkg/vault/secrets.go
@@ -1,8 +1,9 @@
 package vault
 
 import (
-	"github.com/hashicorp/vault/api"
 	"path/filepath"
+
+	"github.com/hashicorp/vault/api"
 )
 
 // Using Vaults Logical client:
@@ -81,7 +82,7 @@ func (v *Vault) ListSecrets(path string) ([]string, error) {
 func (v *Vault) GetSecret(path string) (*api.Secret, error) {
 	secret, err := v.client.Logical().Read(path)
 	if err != nil {
-		return nil, err
+		return nil, v.parseError(err)
 	}
 
 	return secret, nil

--- a/pkg/vault/secrets.go
+++ b/pkg/vault/secrets.go
@@ -15,17 +15,17 @@ func (v *Vault) GetSecretKey(path string, key string) (string, error) {
 
 	secret, err := v.client.Logical().Read(path)
 	if err != nil {
-		return "", v.parseError(err)
+		return "", v.parseError(err).(error)
 	}
 
 	// If we got back an empty response, fail
 	if secret == nil {
-		return "", v.newError("Could not find secret `" + path + "`")
+		return "", v.newError("Could not find secret `" + path + "`").(error)
 	}
 
 	// If the provided key doesn't exist, fail
 	if secret.Data[key] == nil {
-		return "", v.newError("Vault: Could not find key `" + key + "` for secret `" + path + "`")
+		return "", v.newError("Vault: Could not find key `" + key + "` for secret `" + path + "`").(error)
 	}
 
 	return secret.Data[key].(string), nil
@@ -37,7 +37,7 @@ func (v *Vault) GetSecretKeys(path string) (map[string]string, error) {
 
 	secret, err := v.client.Logical().Read(path)
 	if err != nil {
-		return nil, v.parseError(err)
+		return nil, v.parseError(err).(error)
 	}
 
 	// If we got back an empty response, fail
@@ -61,12 +61,12 @@ func (v *Vault) ListSecrets(path string) ([]string, error) {
 
 	secret, err := v.client.Logical().List(path)
 	if err != nil {
-		return nil, v.parseError(err)
+		return nil, v.parseError(err).(error)
 	}
 
 	// If we got back an empty response, fail
 	if secret == nil {
-		return nil, v.newError("Could not find secret `" + path + "`")
+		return nil, v.newError("Could not find secret `" + path + "`").(error)
 	}
 
 	// Loop through and get all the keys
@@ -82,7 +82,7 @@ func (v *Vault) ListSecrets(path string) ([]string, error) {
 func (v *Vault) GetSecret(path string) (*api.Secret, error) {
 	secret, err := v.client.Logical().Read(path)
 	if err != nil {
-		return nil, v.parseError(err)
+		return nil, v.parseError(err).(error)
 	}
 
 	return secret, nil

--- a/pkg/vault/status.go
+++ b/pkg/vault/status.go
@@ -5,11 +5,11 @@ import (
 	"time"
 )
 
-func (v *Vault) isVaultHealthy() (bool, Error) {
+func (v *Vault) isVaultHealthy() (bool, CustomError) {
 
 	result, err := v.client.Sys().Health()
 	if err != nil {
-		return false, v.parseError(err).(Error)
+		return false, v.parseError(err)
 	}
 
 	v.log.Debug("Vault server info from (" + v.client.Address() + ")")

--- a/pkg/vault/status.go
+++ b/pkg/vault/status.go
@@ -5,11 +5,11 @@ import (
 	"time"
 )
 
-func (v *Vault) isVaultHealthy() (bool, error) {
+func (v *Vault) isVaultHealthy() (bool, Error) {
 
 	result, err := v.client.Sys().Health()
 	if err != nil {
-		return false, v.parseError(err)
+		return false, v.parseError(err).(Error)
 	}
 
 	v.log.Debug("Vault server info from (" + v.client.Address() + ")")

--- a/pkg/vault/token.go
+++ b/pkg/vault/token.go
@@ -11,7 +11,7 @@ func (v *Vault) GetCurrentTokenTTL() (time.Duration, error) {
 	// Get the token info from Vault
 	secret, err := v.client.Auth().Token().LookupSelf()
 	if err != nil {
-		return 0, v.parseError(err)
+		return 0, v.parseError(err).(error)
 	}
 
 	// Get our TTL from the Vault secret interface{}

--- a/pkg/vault/token.go
+++ b/pkg/vault/token.go
@@ -11,7 +11,7 @@ func (v *Vault) GetCurrentTokenTTL() (time.Duration, error) {
 	// Get the token info from Vault
 	secret, err := v.client.Auth().Token().LookupSelf()
 	if err != nil {
-		return 0, err
+		return 0, v.parseError(err)
 	}
 
 	// Get our TTL from the Vault secret interface{}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -66,13 +66,13 @@ func New(config *Config) (*Vault, error) {
 	// Ensure Vault is up and Healthy
 	_, err = v.isVaultHealthy()
 	if err != nil {
-		return nil, v.parseError(err)
+		return nil, err
 	}
 
 	// Run Login logic
 	err = v.Login()
 	if err != nil {
-		return nil, v.parseError(err)
+		return nil, err
 	}
 
 	// If user wants, extend the token timeout
@@ -81,13 +81,13 @@ func New(config *Config) (*Vault, error) {
 			v.log.Debug("Attempting to set token duration to ", v.config.InitialTokenDuration)
 			_, err = v.client.Auth().Token().RenewSelf(int(v.config.InitialTokenDuration.Seconds()))
 			if err != nil {
-				return nil, err
+				return nil, v.parseError(err)
 			}
 
 			// Show the actual TTL and warn if different from requested
 			actualDuration, err := v.GetCurrentTokenTTL()
 			if err != nil {
-				return nil, v.parseError(err)
+				return nil, err
 			}
 			v.log.Debug("Current token is valid for {}", actualDuration.String())
 

--- a/stim/vault.go
+++ b/stim/vault.go
@@ -30,6 +30,8 @@ func (stim *Stim) Vault() *vault.Vault {
 			timeInDuration = time.Duration(0)
 		}
 
+		stim.log.Debug("Vault Address: ({})", stim.GetConfig("vault-address"))
+
 		// Create the Vault object and pass in the needed address
 		vault, err := vault.New(&vault.Config{
 			Address:              stim.GetConfig("vault-address"), // Default is 127.0.0.1


### PR DESCRIPTION
Errors where double printing part of the message. We found that parseError was being called two times creating this output: `2019-05-17 10:54:03.870426	[ FATAL ]	Vault Error: Vault Error: Get...`