### PR TITLE
Added TTLs to AWS and AWS Console credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Stim Changelog
 
+## 0.0.6
+
+### Features
+* Added ttl support for AWS logins.  There are two new parameters for the `stim aws login` command:
+  * `-t, --ttl` tells stim to set to AWS credentials ttl to the given value (defaults to `8h`)
+  * `-b, --web-ttl` tells stim to set the AWS web console ttl to the given value (defaults to `1h`).  This value must be between `15m` and `36h`
+
 ## 0.0.5
 
 ### Features

--- a/pkg/aws/credentials.go
+++ b/pkg/aws/credentials.go
@@ -11,7 +11,7 @@ import (
 
 // GetFederationToken takes in a name and returns a set of STS Credentials
 // based on the current session
-func (a *Aws) GetFederationToken(name string) *sts.Credentials {
+func (a *Aws) GetFederationToken(name string, duration time.Duration) *sts.Credentials {
 
 	// Start a new STS session
 	s := sts.New(a.session)
@@ -23,7 +23,8 @@ func (a *Aws) GetFederationToken(name string) *sts.Credentials {
 	stsUserPolicy := "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}]}"
 
 	// Get and the Federated credentials
-	output, err := s.GetFederationToken(&sts.GetFederationTokenInput{Name: &name, Policy: &stsUserPolicy})
+	durationSeconds := int64(duration.Seconds())
+	output, err := s.GetFederationToken(&sts.GetFederationTokenInput{Name: &name, Policy: &stsUserPolicy, DurationSeconds: &durationSeconds})
 	if err != nil {
 		a.log.Fatal("Error getting Federation Token: ", err)
 	}

--- a/pkg/vault/leases.go
+++ b/pkg/vault/leases.go
@@ -1,0 +1,20 @@
+package vault
+
+import (
+	"time"
+)
+
+// Renew lease takes a Vault lease ID and renews it for the provided duration
+// Returns the actual renew time (may be different than requested)
+func (v *Vault) RenewLease(leaseID string, duration time.Duration) (time.Duration, error) {
+
+	v.log.Debug("Renewing lease " + leaseID + " for " + duration.String())
+	secret, err := v.client.Sys().Renew(leaseID, int(duration.Seconds()))
+	if err != nil {
+		return 0, err
+	}
+
+	leaseDuration := time.Duration(secret.LeaseDuration) * time.Second
+
+	return leaseDuration, nil
+}

--- a/stimpacks/aws/command.go
+++ b/stimpacks/aws/command.go
@@ -56,5 +56,11 @@ func (a *Aws) Command(viper *viper.Viper) *cobra.Command {
 	loginCmd.Flags().BoolP("default-profile", "d", false, "If --use-profiles is set, also set as [default] profile")
 	viper.BindPFlag("aws.default-profile", loginCmd.Flags().Lookup("default-profile"))
 
+	loginCmd.Flags().StringP("ttl", "t", "8h", "Time-to-live for AWS credentials")
+	viper.BindPFlag("aws.ttl", loginCmd.Flags().Lookup("ttl"))
+
+	loginCmd.Flags().StringP("web-ttl", "b", "1h", "Time-to-live for AWS web console access (min 15m, max 36h)")
+	viper.BindPFlag("aws.web-ttl", loginCmd.Flags().Lookup("web-ttl"))
+
 	return cmd
 }


### PR DESCRIPTION
* Added ttl support for AWS logins.  There are two new parameters for the `stim aws login` command:
  * `-t, --ttl` tells stim to set to AWS credentials ttl to the given value (defaults to `8h`)
  * `-b, --web-ttl` tells stim to set the AWS web console ttl to the given value (defaults to `1h`).  This value must be between `15m` and `36h`