### PR TITLE
Fixing deploy bug around tool versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Stim Changelog
 
+## 0.1.5
+
+### Bugfix
+* `stim deploy` - Fixed issue with cascading tool versions not working correctly. Certain instance tool versions would overwrite the tool version for other instances.
+
 ## 0.1.4
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
 * `stim deploy` - Fixed issue with cascading tool versions not working correctly. Certain instance tool versions would overwrite the tool version for other instances.
 * Changed displayed username in AWS web console for the STS federated login. The username was 'stim-user' and now matches the LDAP sAMAccountName short name.
 
->>>>>>> master
-
 ## 0.1.4
 
 ### Improvements

--- a/stimpacks/deploy/config.go
+++ b/stimpacks/deploy/config.go
@@ -353,11 +353,15 @@ func mergeSecrets(instance []*v2e.SecretItem, environment []*v2e.SecretItem, glo
 // mergeTools is used to merge tool configurations
 func mergeTools(instance map[string]stim.EnvTool, environment map[string]stim.EnvTool, global map[string]stim.EnvTool) map[string]stim.EnvTool {
 
-	result := global
+	result := make(map[string]stim.EnvTool)
+
+	// Set Global tools
+	for k, v := range environment {
+		result[k] = v
+	}
 
 	// Overwrite with instance tools
 	for k, v := range environment {
-		// fmt.Printf("%v:%v", k, v)
 		if v.Unset == true {
 			delete(result, k)
 		} else {
@@ -367,7 +371,6 @@ func mergeTools(instance map[string]stim.EnvTool, environment map[string]stim.En
 
 	// Overwrite with instance tools
 	for k, v := range instance {
-		// fmt.Printf("%v:%v", k, v)
 		if v.Unset == true {
 			delete(result, k)
 		} else {


### PR DESCRIPTION
`stim deploy` - Fixed issue with cascading tool versions not working correctly. Certain instance tool versions would overwrite the tool version for other instances.