### PR TITLE
Adding tab completion functionality for Bash and Zsh

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/PremiereGlobal/stim/stim"
 	"github.com/PremiereGlobal/stim/stimpacks/aws"
+	"github.com/PremiereGlobal/stim/stimpacks/completion"
 	"github.com/PremiereGlobal/stim/stimpacks/deploy"
 	"github.com/PremiereGlobal/stim/stimpacks/kubernetes"
 	"github.com/PremiereGlobal/stim/stimpacks/pagerduty"
@@ -14,6 +15,7 @@ import (
 func main() {
 	stim := stim.New()
 	stim.AddStimpack(aws.New())
+	stim.AddStimpack(completion.New())
 	stim.AddStimpack(deploy.New())
 	stim.AddStimpack(kubernetes.New())
 	stim.AddStimpack(pagerduty.New())

--- a/stim/completion.go
+++ b/stim/completion.go
@@ -1,0 +1,21 @@
+package stim
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func (stim *Stim) GetCompletion(shell string) error {
+	switch shell {
+	case `bash`:
+		stim.rootCmd.GenBashCompletion(os.Stdout)
+	case `zsh`:
+		stim.rootCmd.GenZshCompletion(os.Stdout)
+		io.WriteString(os.Stdout, "\ncompdef _stim stim\n")
+	default:
+		return fmt.Errorf("Unknown shell: %s", shell)
+	}
+
+	return nil
+}

--- a/stimpacks/completion/completion.go
+++ b/stimpacks/completion/completion.go
@@ -40,6 +40,7 @@ loading it with compinit.
 
 		`,
 		ValidArgs: []string{"bash", "zsh"},
+		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := c.stim.GetCompletion(args[0]); err != nil {
 				fmt.Println(err)

--- a/stimpacks/completion/completion.go
+++ b/stimpacks/completion/completion.go
@@ -1,0 +1,51 @@
+package completion
+
+import (
+	"fmt"
+	"github.com/PremiereGlobal/stim/stim"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type Completion struct {
+	name string
+	stim *stim.Stim
+}
+
+func New() *Completion {
+	return &Completion{name: "completion"}
+}
+
+func (c *Completion) Name() string {
+	return c.name
+}
+
+func (c *Completion) BindStim(s *stim.Stim) {
+	c.stim = s
+}
+
+func (c *Completion) Command(viper *viper.Viper) *cobra.Command {
+
+	var cmd = &cobra.Command{
+		Use:   "completion SHELL",
+		Short: "Output shell completion for the given shell (bash or zsh)",
+		Long: `Output shell completion for the given shell (bash or zsh)
+The following ought to suffice for loading the Bash completions:
+	source <(stim completion bash)
+
+Zsh is more complicated because there is more than one completion engine for
+Zsh. Try putting the completion output into a script (in your $fpath) and 
+loading it with compinit.
+	stim completion zsh > /path/to/script
+
+		`,
+		ValidArgs: []string{"bash", "zsh"},
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := c.stim.GetCompletion(args[0]); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+
+	return cmd
+}


### PR DESCRIPTION
Pretty small addition to the code base but I felt it was a worthy one since `cobra` has completion generation built in. 

Comments welcome, and rejection too.