### PR TITLE
added filters for cluster and service account

### DIFF
--- a/stimpacks/aws/getCredentials.go
+++ b/stimpacks/aws/getCredentials.go
@@ -25,7 +25,7 @@ func (a *Aws) GetCredentials() (string, string, error) {
 	if vaultRole == "" && a.stim.IsAutomated() {
 		a.stim.Fatal(errors.New("Vault aws role not specified"))
 	} else if vaultRole == "" {
-		vaultRole, err = a.stim.PromptListVault(vaultAccount+"/roles", "Select Role", "")
+		vaultRole, err = a.stim.PromptListVault(vaultAccount+"/roles", "Select Role", "", "")
 		a.stim.Fatal(err)
 	}
 

--- a/stimpacks/kubernetes/command.go
+++ b/stimpacks/kubernetes/command.go
@@ -38,6 +38,10 @@ func (k *Kubernetes) Command(viper *viper.Viper) *cobra.Command {
 	viper.BindPFlag("kube-current-context", configCmd.Flags().Lookup("current-context"))
 	configCmd.Flags().StringP("namespace", "n", "", "Optional. Name of default namespace")
 	viper.BindPFlag("kube-config-namespace", configCmd.Flags().Lookup("namespace"))
+	configCmd.Flags().StringP("cf", "", "", "Optional. Cluster regex filter")
+	viper.BindPFlag("kube.cluster.filter", configCmd.Flags().Lookup("cf"))
+	configCmd.Flags().StringP("saf", "", "", "Optional. Service Account regex filter")
+	viper.BindPFlag("kube.service-account.filter", configCmd.Flags().Lookup("saf"))
 
 	k.stim.BindCommand(configCmd, cmd)
 

--- a/stimpacks/kubernetes/configure.go
+++ b/stimpacks/kubernetes/configure.go
@@ -12,12 +12,12 @@ func (k *Kubernetes) configureContext() error {
 
 	var err error
 
-	cluster, err := k.stim.PromptListVault("secret/kubernetes", "Select Cluster", k.stim.ConfigGetString("kube-config-cluster"))
+	cluster, err := k.stim.PromptListVault("secret/kubernetes", "Select Cluster", k.stim.ConfigGetString("kube-config-cluster"), k.stim.ConfigGetString("kube.cluster.filter"))
 	if err != nil {
 		return err
 	}
 
-	sa, err := k.stim.PromptListVault("secret/kubernetes/"+cluster, "Select Service Account", k.stim.ConfigGetString("kube-service-account"))
+	sa, err := k.stim.PromptListVault("secret/kubernetes/"+cluster, "Select Service Account", k.stim.ConfigGetString("kube-service-account"), k.stim.ConfigGetString("kube.service-account.filter"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change allows the stim config to have
```
kube:
  cluster:
    filter: ".*dev.*"
  service-account:
    filter: ".*admin.*"
```
as well as adding --cf and --saf to the `stim kube config` command.
it addresses #59 