### PR TITLE
allow all config options to also be envVars using subpaths 

### DIFF
--- a/stim/config.go
+++ b/stim/config.go
@@ -13,7 +13,15 @@ import (
 )
 
 func (stim *Stim) ConfigGetRaw(configKey string) interface{} {
+	var envCV interface{} = nil
 	configValue := stim.config.Get(configKey)
+	if strings.Contains(configKey, ".") {
+		envCK := strings.ReplaceAll(configKey, ".", "-")
+		envCV = stim.config.Get(envCK)
+	}
+	if envCV != nil {
+		return envCV
+	}
 	if configValue != nil {
 		return configValue
 	}
@@ -22,13 +30,21 @@ func (stim *Stim) ConfigGetRaw(configKey string) interface{} {
 }
 
 func (stim *Stim) ConfigGetString(configKey string) string {
+	var envCV string = ""
 	configValue := stim.config.GetString(configKey)
+	if strings.Contains(configKey, ".") {
+		envCK := strings.ReplaceAll(configKey, ".", "-")
+		envCV = stim.config.GetString(envCK)
+	}
+	if envCV != "" {
+		return envCV
+	}
 	return configValue
 }
 
 // GetConfigBool takes a config key and returns the boolean result
 func (stim *Stim) ConfigGetBool(configKey string) bool {
-	configValue := stim.config.Get(configKey)
+	configValue := stim.ConfigGetRaw(configKey)
 	if configValue != nil {
 		return configValue.(bool)
 	}
@@ -37,6 +53,13 @@ func (stim *Stim) ConfigGetBool(configKey string) bool {
 
 func (stim *Stim) ConfigHasValue(configKey string) bool {
 	configValue := stim.config.Get(configKey)
+	if strings.Contains(configKey, ".") {
+		envCK := strings.ReplaceAll(configKey, ".", "-")
+		envCV := stim.config.Get(envCK)
+		if envCV != nil {
+			return true
+		}
+	}
 	if configValue != nil {
 		return true
 	}
@@ -141,6 +164,7 @@ func (stim *Stim) writeConfigData(config map[string]interface{}) error {
 		stim.log.Debug("Problem writing configfile:{}", err)
 		return err
 	}
+	stim.getConfigData()
 	return nil
 }
 

--- a/stim/config.go
+++ b/stim/config.go
@@ -1,6 +1,7 @@
 package stim
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -46,7 +47,16 @@ func (stim *Stim) ConfigGetString(configKey string) string {
 func (stim *Stim) ConfigGetBool(configKey string) bool {
 	configValue := stim.ConfigGetRaw(configKey)
 	if configValue != nil {
-		return configValue.(bool)
+		switch v := configValue.(type) {
+		case bool:
+			return v
+		case string:
+			lc := strings.ToLower(v)
+			return lc == "true" || lc == "t"
+		default:
+			stim.log.Warn("Unknown type for bool, type:{}, value of:{}", fmt.Sprintf("%T", v), v)
+		}
+
 	}
 	return false
 }

--- a/stim/config_test.go
+++ b/stim/config_test.go
@@ -3,6 +3,7 @@ package stim
 import (
 	"testing"
 
+	"github.com/PremiereGlobal/stim/pkg/stimlog"
 	"github.com/spf13/viper"
 	"gotest.tools/assert"
 )
@@ -46,15 +47,25 @@ func TestSimpleGetRaw(t *testing.T) {
 func TestSimpleGetBool(t *testing.T) {
 	stim := &Stim{
 		config: viper.New(),
+		log:    stimlog.GetLogger(),
 	}
 	stim.config.SetDefault("TEST-VALUE-TRUE", true)
+	stim.config.SetDefault("TEST-VALUE-TRUE-STRING", "true")
+	stim.config.SetDefault("TEST-VALUE-TRUE-STRING2", "bad")
+	stim.config.SetDefault("TEST-VALUE-TRUE-INT", 100)
 
 	simple := stim.ConfigGetBool("test-value-true")
 	simple2 := stim.ConfigGetBool("test.value-true")
+	simple3 := stim.ConfigGetBool("test.value-true.string")
+	simple4 := stim.ConfigGetBool("test.value-true.string2")
+	simple5 := stim.ConfigGetBool("test.value-true.int")
 	none := stim.ConfigGetBool("test.value-false")
 
 	assert.Equal(t, true, simple, "Values not Equal")
 	assert.Equal(t, true, simple2, "Values not Equal")
+	assert.Equal(t, true, simple3, "Values not Equal")
+	assert.Equal(t, false, simple4, "Values not Equal")
+	assert.Equal(t, false, simple5, "Values not Equal")
 	assert.Equal(t, false, none, "Values not Equal")
 }
 

--- a/stim/config_test.go
+++ b/stim/config_test.go
@@ -1,0 +1,76 @@
+package stim
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"gotest.tools/assert"
+)
+
+func check(e error) {
+	if e != nil {
+		panic(e)
+	}
+}
+
+func TestSimpleGetString(t *testing.T) {
+	stim := &Stim{
+		config: viper.New(),
+	}
+	stim.config.SetDefault("TEST-VALUE-ONE", "ONE")
+
+	simple := stim.ConfigGetString("test-value-one")
+	simple2 := stim.ConfigGetString("test.value-one")
+	none := stim.ConfigGetString("test.value-two")
+
+	assert.Equal(t, "ONE", simple, "Values not Equal")
+	assert.Equal(t, "ONE", simple2, "Values not Equal")
+	assert.Equal(t, "", none, "Values not Equal")
+}
+
+func TestSimpleGetRaw(t *testing.T) {
+	stim := &Stim{
+		config: viper.New(),
+	}
+	stim.config.SetDefault("TEST-VALUE-ONE", "ONE")
+
+	simple := stim.ConfigGetRaw("test-value-one")
+	simple2 := stim.ConfigGetRaw("test.value-one")
+	none := stim.ConfigGetRaw("test.value-two")
+
+	assert.Equal(t, "ONE", simple, "Values not Equal")
+	assert.Equal(t, "ONE", simple2, "Values not Equal")
+	assert.Equal(t, nil, none, "Values not Equal")
+}
+
+func TestSimpleGetBool(t *testing.T) {
+	stim := &Stim{
+		config: viper.New(),
+	}
+	stim.config.SetDefault("TEST-VALUE-TRUE", true)
+
+	simple := stim.ConfigGetBool("test-value-true")
+	simple2 := stim.ConfigGetBool("test.value-true")
+	none := stim.ConfigGetBool("test.value-false")
+
+	assert.Equal(t, true, simple, "Values not Equal")
+	assert.Equal(t, true, simple2, "Values not Equal")
+	assert.Equal(t, false, none, "Values not Equal")
+}
+
+func TestHasValue(t *testing.T) {
+	stim := &Stim{
+		config: viper.New(),
+	}
+	stim.config.SetDefault("TEST-VALUE-TRUE", true)
+
+	yes := stim.ConfigHasValue("test-value-true")
+	yes2 := stim.ConfigHasValue("test.value-true")
+	yes3 := stim.ConfigHasValue("test.value.true")
+	no := stim.ConfigHasValue("test-value-false")
+
+	assert.Equal(t, true, yes, "Values not Equal")
+	assert.Equal(t, true, yes2, "Values not Equal")
+	assert.Equal(t, true, yes3, "Values not Equal")
+	assert.Equal(t, false, no, "Values not Equal")
+}


### PR DESCRIPTION
allow all config options to also be envVars including subpaths with a '.' then get translated to - in viper config