### PR TITLE
adds --filter-prompts option to aws login command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,18 @@
 # Stim Changelog
+
+## 0.4.0
+### Improvements
+* Added `--filter-prompts` to `aws login` to limit shown accounts and roles according to Vault token capabilities
+
 ## 0.3.2
 ### Bugfix
 * Fixed setting of default values
-
-
 
 ## 0.3.1
 ### Improvements
 * changed thottle to 5 times and 2/4/8/16/32 sec
 ### Bugfix
 * still fail if throttling happens more then 5 times
-
 
 ## 0.3.0
 ### Improvements

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/krolaw/zipstream v0.0.0-20180621105154-0a2661891f94
 	github.com/manifoldco/promptui v0.3.2
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mitchellh/mapstructure v1.1.2
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/nicksnyder/go-i18n v1.10.0 // indirect
 	github.com/nlopes/slack v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/krolaw/zipstream v0.0.0-20180621105154-0a2661891f94
 	github.com/manifoldco/promptui v0.3.2
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/mitchellh/mapstructure v1.1.2
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/nicksnyder/go-i18n v1.10.0 // indirect
 	github.com/nlopes/slack v0.6.0

--- a/pkg/vault/capabilities.go
+++ b/pkg/vault/capabilities.go
@@ -1,0 +1,42 @@
+package vault
+
+import (
+	"github.com/hashicorp/vault/api"
+	"github.com/mitchellh/mapstructure"
+
+	"context"
+)
+
+type CapabilitiesSelfOptions struct {
+	Paths []string `json:"paths,omitempty"`
+}
+
+type CapabilitiesSelfResults map[string][]string
+
+func (v *Vault) CapabilitiesSelf(opts *CapabilitiesSelfOptions) (CapabilitiesSelfResults, error) {
+	request := v.client.NewRequest("POST", "/v1/sys/capabilities-self")
+	if err := request.SetJSONBody(opts); err != nil {
+		return nil, err
+	}
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	response, err := v.client.RawRequestWithContext(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	parsedSecret, err := api.ParseSecret(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var results CapabilitiesSelfResults
+	err = mapstructure.Decode(parsedSecret.Data, &results)
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}

--- a/pkg/vault/filter.go
+++ b/pkg/vault/filter.go
@@ -23,7 +23,7 @@ func (v *Vault) Filter(paths []string, withCapabilities []string) ([]string, err
 	}
 
 	var filteredPaths []string
-	for path, capabilities := range results {
+	for path, capabilities := range results.Data {
 		for _, capability := range withCapabilities {
 			if utils.Contains(capabilities, capability) {
 				filteredPaths = append(filteredPaths, path)

--- a/pkg/vault/filter.go
+++ b/pkg/vault/filter.go
@@ -1,0 +1,36 @@
+package vault
+
+import (
+	"github.com/PremiereGlobal/stim/pkg/utils"
+)
+
+func (v *Vault) Filter(paths []string, withCapabilities []string) ([]string, error) {
+	if len(paths) == 0 {
+		return []string{}, nil
+	}
+
+	opts := &CapabilitiesSelfOptions{
+		Paths: paths,
+	}
+
+	results, err := v.CapabilitiesSelf(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(withCapabilities) == 0 {
+		withCapabilities = []string{"list", "read"}
+	}
+
+	var filteredPaths []string
+	for path, capabilities := range results {
+		for _, capability := range withCapabilities {
+			if utils.Contains(capabilities, capability) {
+				filteredPaths = append(filteredPaths, path)
+				break
+			}
+		}
+	}
+
+	return filteredPaths, nil
+}

--- a/stimpacks/aws/command.go
+++ b/stimpacks/aws/command.go
@@ -62,5 +62,8 @@ func (a *Aws) Command(viper *viper.Viper) *cobra.Command {
 	loginCmd.Flags().StringP("web-ttl", "b", "1h", "Time-to-live for AWS web console access (min 15m, max 36h)")
 	viper.BindPFlag("aws.web-ttl", loginCmd.Flags().Lookup("web-ttl"))
 
+	loginCmd.Flags().BoolP("filter-prompts", "", false, "Show accounts and roles according to Vault token capabilities")
+	viper.BindPFlag("aws.filter-prompts", loginCmd.Flags().Lookup("filter-prompts"))
+
 	return cmd
 }

--- a/stimpacks/aws/getCredentials.go
+++ b/stimpacks/aws/getCredentials.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"errors"
+	"sort"
+	"strings"
 )
 
 // GetCredentials will get the aws mount and role from the user
@@ -10,14 +12,12 @@ func (a *Aws) GetCredentials() (string, string, error) {
 		a.vault = a.stim.Vault()
 	}
 
-	mounts, err := a.vault.GetMounts("aws")
-	a.stim.Fatal(err)
-
 	vaultAccount := a.stim.ConfigGetString("aws.account")
 	if vaultAccount == "" && a.stim.IsAutomated() {
 		a.stim.Fatal(errors.New("Vault aws mount not specified"))
 	} else if vaultAccount == "" {
-		vaultAccount, err = a.stim.PromptSearchList("Choose AWS account", mounts)
+		filteredAccounts, err := a.filterAccounts()
+		vaultAccount, err = a.stim.PromptSearchList("Choose AWS account", filteredAccounts)
 		a.stim.Fatal(err)
 	}
 
@@ -25,9 +25,60 @@ func (a *Aws) GetCredentials() (string, string, error) {
 	if vaultRole == "" && a.stim.IsAutomated() {
 		a.stim.Fatal(errors.New("Vault aws role not specified"))
 	} else if vaultRole == "" {
-		vaultRole, err = a.stim.PromptListVault(vaultAccount+"/roles", "Select Role", "", "")
+		filteredRoles, err := a.filterRoles(vaultAccount)
+		vaultRole, err = a.stim.PromptList("Select Role", filteredRoles, "")
 		a.stim.Fatal(err)
 	}
 
 	return vaultAccount, vaultRole, nil
+}
+
+func (a *Aws) filterAccounts() ([]string, error) {
+	mounts, err := a.vault.GetMounts("aws")
+	a.stim.Fatal(err)
+	if !a.stim.ConfigGetBool("aws.filter-prompts") {
+		return mounts, nil
+	}
+
+	var rolesPaths []string
+	for _, mount := range mounts {
+		rolesPaths = append(rolesPaths, mount+"/roles")
+	}
+
+	filteredPaths, err := a.vault.Filter(rolesPaths, []string{"list"})
+	a.stim.Fatal(err)
+
+	var filteredAccounts []string
+	for _, path := range filteredPaths {
+		account := strings.TrimSuffix(path, "/roles")
+		filteredAccounts = append(filteredAccounts, account)
+	}
+
+	sort.Strings(filteredAccounts)
+	return filteredAccounts, nil
+}
+
+func (a *Aws) filterRoles(vaultAccount string) ([]string, error) {
+	roles, err := a.vault.ListSecrets(vaultAccount + "/roles")
+	a.stim.Fatal(err)
+	if !a.stim.ConfigGetBool("aws.filter-prompts") {
+		return roles, nil
+	}
+
+	var credsPaths []string
+	for _, role := range roles {
+		credsPaths = append(credsPaths, vaultAccount+"/creds/"+role)
+	}
+
+	filteredPaths, err := a.vault.Filter(credsPaths, []string{"read"})
+	a.stim.Fatal(err)
+
+	var filteredRoles []string
+	for _, path := range filteredPaths {
+		role := strings.TrimPrefix(path, vaultAccount+"/creds/")
+		filteredRoles = append(filteredRoles, role)
+	}
+
+	sort.Strings(filteredRoles)
+	return filteredRoles, nil
 }


### PR DESCRIPTION
## Problem

`stim aws login` presents an unfiltered list of AWS accounts and roles to the user whether their vault token has access to them or not.

## Solution

`stim aws login` now takes an optional `--filter-prompts` which when `true` causes stim to ask vault for the capabilities of the user's vault token to filter AWS accounts, and then again to filter the roles for the selected account.

## Performance Impact

In my testing, presenting unfiltered AWS accounts takes 300ms, where presenting filtered AWS accounts takes 600ms.  Presenting unfiltered roles takes 250ms where presenting filtered roles takes 500ms.

This is not surprising since we are adding 1 more call to vault to filter secrets paths for both AWS accounts and roles.

## Implementation Details

`Vault` gains a `Filter` method which takes a list of secrets paths and returns a subset of that list of secrets paths for which the user's token has at least one of `{"list", "read"}` (configurable).

`Vault` gains a `CapabilitiesSelf` method which takes a list of secrets paths and returns the user's token's capabilities for each of those paths.

`stim aws login` gains a `--filter-prompts` option (default: `false`) when `true` uses `Vault.Filter` on the AWS mounts and roles.  The `aws.filter-prompts` config file option may be set to `true` to gain the same behavior.

## Vault HTTP API

The vault Golang client's `CapabilitiesSelf` is presently incompatible with the vault HTTP API's `/sys/capabilities-self`'s response which returns a map, so we're using `NewRequest/RawRequestWithContext` to communicate with the HTTP API directly.

> Context:
> - HTTP API: [https://www.vaultproject.io/api/system/capabilities-self](https://www.vaultproject.io/api/system/capabilities-self)
> - HTTP API Commit: [https://github.com/hashicorp/vault/commit/e7524b816d069685f7547d190a82f58812747a2c](https://github.com/hashicorp/vault/commit/e7524b816d069685f7547d190a82f58812747a2c)
> - Included in 0.9.6 (March 20th, 2018) as an improvement: [https://gitlab.umich.edu/flowerysong/vault/-/blob/master/CHANGELOG.md#096-march-20th-2018](https://gitlab.umich.edu/flowerysong/vault/-/blob/master/CHANGELOG.md#096-march-20th-2018)
> - Golang Client: [https://github.com/hashicorp/vault/blob/master/api/sys\_capabilities.go](https://github.com/hashicorp/vault/blob/master/api/sys\_capabilities.go)


## Verifying Behavior

1. Create a vault token with limited AWS account access
2. Put that token in `~/.vault-token`
3. `go run main.go aws login --filter-prompts`
4. Observe limited AWS accounts and roles lists

In my setup on vault 1.5.7, I had to create an orphan token in order to "remove" the `vault-admin` policy from my resultant tokens.  A policy with `list` capability on `sys/mounts` is necessary as well, which in my setup was provided by a `global-default` policy.

So something like `vault token create -policy="global-default" -policy="specific-aws-policy" -orphan="true" -ttl="30m"` may be necessary for you to generate tokens with limited AWS access.