### PR TITLE
Kube config filter by token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.4.0
 ### Improvements
-* Added `--filter-prompts` to `aws login` to limit shown accounts and roles according to Vault token capabilities
+* Added `--filter-by-token` to `aws login` to limit shown accounts and roles according to Vault token capabilities
+* Added `--filter-by-token` to `kube config` to limit shown service accounts according to Vault token capabilities
 
 ## 0.3.2
 ### Bugfix

--- a/pkg/utils/slice.go
+++ b/pkg/utils/slice.go
@@ -1,5 +1,9 @@
 package utils
 
+import (
+	"regexp"
+)
+
 func Contains(s []string, e string) bool {
 	for _, a := range s {
 		if a == e {
@@ -7,4 +11,23 @@ func Contains(s []string, e string) bool {
 		}
 	}
 	return false
+}
+
+func Filter(list []string, regex string) ([]string, error) {
+	if regex == "" {
+		return list, nil
+	}
+
+	filtered := make([]string, 0)
+	matcher, err := regexp.Compile(regex)
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range list {
+		if matcher.MatchString(v) {
+			filtered = append(filtered, v)
+		}
+	}
+
+	return filtered, nil
 }

--- a/pkg/vault/filter.go
+++ b/pkg/vault/filter.go
@@ -25,12 +25,11 @@ func (v *Vault) Filter(paths []string, withCapabilities []string) ([]string, err
 	var filteredPaths []string
 	for path, capabilities := range results.Data {
 		for _, capability := range withCapabilities {
-			if path == "capabilities" {
-				continue
-			}
 			if utils.Contains(capabilities, capability) {
-				filteredPaths = append(filteredPaths, path)
-				break
+				if path != "capabilities" {
+					filteredPaths = append(filteredPaths, path)
+					break
+				}
 			}
 		}
 	}

--- a/pkg/vault/filter.go
+++ b/pkg/vault/filter.go
@@ -25,6 +25,9 @@ func (v *Vault) Filter(paths []string, withCapabilities []string) ([]string, err
 	var filteredPaths []string
 	for path, capabilities := range results.Data {
 		for _, capability := range withCapabilities {
+			if path == "capabilities" {
+				continue
+			}
 			if utils.Contains(capabilities, capability) {
 				filteredPaths = append(filteredPaths, path)
 				break

--- a/stim/config.go
+++ b/stim/config.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (stim *Stim) ConfigSetDefaultValues() {
-	stim.config.SetDefault("kube.config.path", "secret/kubernetes/")
+	stim.config.SetDefault("kube.config.path", "secret/kubernetes")
 	stim.config.SetDefault("kube.config.keyname", "kube-config")
 	stim.config.SetDefault("vault.retryOnThrottle", false)
 	stim.config.SetDefault("vault.address", "https://127.0.0.1:8200/")

--- a/stim/prompt.go
+++ b/stim/prompt.go
@@ -2,9 +2,9 @@ package stim
 
 import (
 	"os"
-	"regexp"
 	"strings"
 
+	"github.com/PremiereGlobal/stim/pkg/utils"
 	"github.com/chzyer/readline"
 	"github.com/manifoldco/promptui"
 )
@@ -133,25 +133,12 @@ func (stim *Stim) PromptListVault(vaultPath string, label string, defaultedValue
 		return "", err
 	}
 
-	listRegex := make([]string, 0)
-	if regex != "" {
-		stim.log.Debug("Doing Regex on vault list: \"{}\"", regex)
-		matcher, err := regexp.Compile(regex)
-		if err != nil {
-			stim.log.Warn("Problem parsing regex filter:\"{}\", err:{}, skipping regex.", regex, err)
-			listRegex = list
-		} else {
-			for _, v := range list {
-				if matcher.MatchString(v) {
-					listRegex = append(listRegex, v)
-				}
-			}
-		}
-	} else {
-		listRegex = list
+	filteredList, err := utils.Filter(list, regex)
+	if err != nil {
+		return "", err
 	}
 
-	result, err := stim.PromptList(label, listRegex, "")
+	result, err := stim.PromptList(label, filteredList, "")
 	if err != nil {
 		return "", err
 	}

--- a/stimpacks/aws/command.go
+++ b/stimpacks/aws/command.go
@@ -62,8 +62,8 @@ func (a *Aws) Command(viper *viper.Viper) *cobra.Command {
 	loginCmd.Flags().StringP("web-ttl", "b", "1h", "Time-to-live for AWS web console access (min 15m, max 36h)")
 	viper.BindPFlag("aws.web-ttl", loginCmd.Flags().Lookup("web-ttl"))
 
-	loginCmd.Flags().BoolP("filter-prompts", "", false, "Show accounts and roles according to Vault token capabilities")
-	viper.BindPFlag("aws.filter-prompts", loginCmd.Flags().Lookup("filter-prompts"))
+	loginCmd.Flags().BoolP("filter-by-token", "", false, "Show accounts and roles according to Vault token capabilities")
+	viper.BindPFlag("aws.filter-by-token", loginCmd.Flags().Lookup("filter-by-token"))
 
 	return cmd
 }

--- a/stimpacks/aws/command.go
+++ b/stimpacks/aws/command.go
@@ -63,7 +63,7 @@ func (a *Aws) Command(viper *viper.Viper) *cobra.Command {
 	viper.BindPFlag("aws.web-ttl", loginCmd.Flags().Lookup("web-ttl"))
 
 	loginCmd.Flags().BoolP("filter-by-token", "", false, "Show accounts and roles according to Vault token capabilities")
-	viper.BindPFlag("aws.filter-by-token", loginCmd.Flags().Lookup("filter-by-token"))
+	viper.BindPFlag("aws.login.filter-by-token", loginCmd.Flags().Lookup("filter-by-token"))
 
 	return cmd
 }

--- a/stimpacks/aws/getCredentials.go
+++ b/stimpacks/aws/getCredentials.go
@@ -36,7 +36,7 @@ func (a *Aws) GetCredentials() (string, string, error) {
 func (a *Aws) filterAccounts() ([]string, error) {
 	mounts, err := a.vault.GetMounts("aws")
 	a.stim.Fatal(err)
-	if !a.stim.ConfigGetBool("aws.filter-prompts") {
+	if !a.stim.ConfigGetBool("aws.filter-by-token") {
 		return mounts, nil
 	}
 
@@ -61,7 +61,7 @@ func (a *Aws) filterAccounts() ([]string, error) {
 func (a *Aws) filterRoles(vaultAccount string) ([]string, error) {
 	roles, err := a.vault.ListSecrets(vaultAccount + "/roles")
 	a.stim.Fatal(err)
-	if !a.stim.ConfigGetBool("aws.filter-prompts") {
+	if !a.stim.ConfigGetBool("aws.filter-by-token") {
 		return roles, nil
 	}
 

--- a/stimpacks/aws/getCredentials.go
+++ b/stimpacks/aws/getCredentials.go
@@ -36,7 +36,7 @@ func (a *Aws) GetCredentials() (string, string, error) {
 func (a *Aws) filterAccounts() ([]string, error) {
 	mounts, err := a.vault.GetMounts("aws")
 	a.stim.Fatal(err)
-	if !a.stim.ConfigGetBool("aws.filter-by-token") {
+	if !a.stim.ConfigGetBool("aws.login.filter-by-token") {
 		return mounts, nil
 	}
 
@@ -61,7 +61,7 @@ func (a *Aws) filterAccounts() ([]string, error) {
 func (a *Aws) filterRoles(vaultAccount string) ([]string, error) {
 	roles, err := a.vault.ListSecrets(vaultAccount + "/roles")
 	a.stim.Fatal(err)
-	if !a.stim.ConfigGetBool("aws.filter-by-token") {
+	if !a.stim.ConfigGetBool("aws.login.filter-by-token") {
 		return roles, nil
 	}
 

--- a/stimpacks/kubernetes/command.go
+++ b/stimpacks/kubernetes/command.go
@@ -39,11 +39,11 @@ func (k *Kubernetes) Command(viper *viper.Viper) *cobra.Command {
 	configCmd.Flags().StringP("namespace", "n", "", "Optional. Name of default namespace")
 	viper.BindPFlag("kube-config-namespace", configCmd.Flags().Lookup("namespace"))
 	configCmd.Flags().StringP("cf", "", "", "Optional. Cluster regex filter")
-	viper.BindPFlag("kube.cluster.filter", configCmd.Flags().Lookup("cf"))
+	viper.BindPFlag("kube.config.cluster-filter", configCmd.Flags().Lookup("cf"))
 	configCmd.Flags().StringP("saf", "", "", "Optional. Service Account regex filter")
-	viper.BindPFlag("kube.service-account.filter", configCmd.Flags().Lookup("saf"))
+	viper.BindPFlag("kube.config.service-account-filter", configCmd.Flags().Lookup("saf"))
 	configCmd.Flags().BoolP("filter-by-token", "", false, "Optional. Show service accounts by Vault token capabilities")
-	viper.BindPFlag("kube.filter-by-token", configCmd.Flags().Lookup("filter-by-token"))
+	viper.BindPFlag("kube.config.filter-by-token", configCmd.Flags().Lookup("filter-by-token"))
 
 	k.stim.BindCommand(configCmd, cmd)
 

--- a/stimpacks/kubernetes/command.go
+++ b/stimpacks/kubernetes/command.go
@@ -42,6 +42,8 @@ func (k *Kubernetes) Command(viper *viper.Viper) *cobra.Command {
 	viper.BindPFlag("kube.cluster.filter", configCmd.Flags().Lookup("cf"))
 	configCmd.Flags().StringP("saf", "", "", "Optional. Service Account regex filter")
 	viper.BindPFlag("kube.service-account.filter", configCmd.Flags().Lookup("saf"))
+	configCmd.Flags().BoolP("filter-by-token", "", false, "Optional. Show service accounts by Vault token capabilities")
+	viper.BindPFlag("kube.filter-by-token", configCmd.Flags().Lookup("filter-by-token"))
 
 	k.stim.BindCommand(configCmd, cmd)
 

--- a/stimpacks/kubernetes/configure.go
+++ b/stimpacks/kubernetes/configure.go
@@ -21,6 +21,9 @@ func (k *Kubernetes) configureContext() error {
 		cluster = k.stim.ConfigGetString("kube-config-cluster") //TODO: depreciated config should be removed
 	}
 	kubeClusterFilter := k.stim.ConfigGetString("kube.config.cluster-filter")
+	if kubeClusterFilter == "" {
+		kubeClusterFilter = k.stim.ConfigGetString("kube.cluster.filter") //TODO: depreciated config should be removed
+	}
 
 	kubePath := k.stim.ConfigGetString("kube.config.path")
 
@@ -34,6 +37,9 @@ func (k *Kubernetes) configureContext() error {
 		sa = k.stim.ConfigGetString("kube-service-account") //TODO: depreciated config should be removed
 	}
 	saFilter := k.stim.ConfigGetString("kube.config.service-account-filter")
+	if saFilter == "" {
+		saFilter = k.stim.ConfigGetString("kube.config.serviceaccountfilter") //TODO: depreciated config should be removed
+	}
 
 	filteredServiceAccounts, err := k.filterServiceAccounts(kubePath+"/"+cluster, saFilter)
 	if err != nil {

--- a/stimpacks/kubernetes/configure.go
+++ b/stimpacks/kubernetes/configure.go
@@ -20,7 +20,7 @@ func (k *Kubernetes) configureContext() error {
 	if cluster == "" {
 		cluster = k.stim.ConfigGetString("kube-config-cluster") //TODO: depreciated config should be removed
 	}
-	kubeClusterFilter := k.stim.ConfigGetString("kube.cluster.filter")
+	kubeClusterFilter := k.stim.ConfigGetString("kube.config.cluster-filter")
 
 	kubePath := k.stim.ConfigGetString("kube.config.path")
 
@@ -33,7 +33,7 @@ func (k *Kubernetes) configureContext() error {
 	if sa == "" {
 		sa = k.stim.ConfigGetString("kube-service-account") //TODO: depreciated config should be removed
 	}
-	saFilter := k.stim.ConfigGetString("kube.service-account.filter")
+	saFilter := k.stim.ConfigGetString("kube.config.service-account-filter")
 
 	filteredServiceAccounts, err := k.filterServiceAccounts(kubePath+"/"+cluster, saFilter)
 	if err != nil {
@@ -113,7 +113,7 @@ func (k *Kubernetes) filterServiceAccounts(path string, saFilter string) ([]stri
 	regexFilteredServiceAccounts, err := utils.Filter(serviceAccounts, saFilter)
 	k.stim.Fatal(err)
 
-	if !k.stim.ConfigGetBool("kube.filter-by-token") {
+	if !k.stim.ConfigGetBool("kube.config.filter-by-token") {
 		return regexFilteredServiceAccounts, nil
 	}
 


### PR DESCRIPTION
* adds `--filter-by-token` option to `kube config` command
* renames `--filter-prompts` option in `aws login` to `--filter-by-token` for consistency

Tested `stim kube config` with every permutation of providing 1, 2 or 3 of `--cf`, `--saf` and `--filter-by-token`.

* fixes an edge case in `vault.Filter`

Vault's `CapabilitiesSelf` returns a "path" called `capabilities` when
it receives only a single path in its request.  Presumably this is for
backward compatibility.  It also returns the path with its capabilities,
as it would when it returns a list of paths with their capabilities,
which is what consumers of `vault.Filter` expect.

So we just throw away the `capabilities` "path".  Otherwise users would
see a dummy `capabilities` role along with the single expected role on
`aws login` with `--filter-by-token` when the aws account only has a
single role defined, or if their service account filter via `--saf`
narrowed the set of possible roles down to 1.